### PR TITLE
Implement Swagger UI for API Documentation

### DIFF
--- a/packages/backend/docs/swagger-README.md
+++ b/packages/backend/docs/swagger-README.md
@@ -1,0 +1,94 @@
+# Glizzy Gobbler 4000 API Documentation
+
+## Overview
+
+This directory contains the API documentation setup using Swagger UI. The documentation provides a user-friendly interface to explore and test the API endpoints.
+
+## Accessing the Documentation
+
+The Swagger UI documentation is available at:
+
+```
+http://localhost:5000/api-docs
+```
+
+When the server is running, you can access this URL in your browser to see the API documentation.
+
+## Features
+
+- Interactive API documentation
+- Request/response examples
+- Authentication documentation
+- Model schemas
+- Test endpoints directly from the UI
+
+## Structure
+
+The Swagger documentation is configured in multiple files:
+
+1. `swagger.config.mjs` - Main configuration file that sets up the OpenAPI specification
+2. JSDoc comments in route files (e.g., `auth.routes.mjs`) - Documents individual endpoints
+3. JSDoc comments in controller files - Provides additional endpoint documentation
+4. Model schemas defined in the Swagger configuration
+
+## Adding Documentation for New Endpoints
+
+When adding new endpoints to the API, follow these steps to ensure they are properly documented:
+
+1. Add JSDoc comments above the route definition in your route file:
+
+```javascript
+/**
+ * @swagger
+ * /api/your-endpoint:
+ *   get:
+ *     tags: [YourTag]
+ *     summary: Short description
+ *     description: Detailed description
+ *     parameters:
+ *       - name: paramName
+ *         in: query
+ *         description: Parameter description
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Success response description
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/YourSchema'
+ */
+router.get('/your-endpoint', yourController);
+```
+
+2. Add JSDoc comments in your controller file for additional context:
+
+```javascript
+/**
+ * Controller description
+ * @route GET /api/your-endpoint
+ * @access Public|Private
+ */
+export const yourController = (req, res) => { ... };
+```
+
+3. If needed, add new schemas to the `swagger.config.mjs` file under the `components.schemas` section.
+
+## Authentication
+
+The API uses JWT tokens stored in HttpOnly cookies for authentication. The Swagger UI is configured to support this authentication method. To test protected endpoints:
+
+1. First, login using the `/api/auth/login` endpoint
+2. The API will set the authentication cookie automatically
+3. Then, you can test protected endpoints that require authentication
+
+## Development
+
+When modifying the Swagger configuration:
+
+1. Update the `swagger.config.mjs` file for global changes
+2. Make sure all route files use consistent JSDoc comments
+3. Keep model schemas up to date in the Swagger configuration
+4. Test the documentation by accessing the Swagger UI after changes

--- a/packages/backend/src/utils/swagger.config.mjs
+++ b/packages/backend/src/utils/swagger.config.mjs
@@ -1,0 +1,320 @@
+/**
+ * Swagger Configuration
+ * 
+ * This file configures the Swagger UI interface and the OpenAPI specification
+ * for the API documentation.
+ */
+import swaggerJSDoc from 'swagger-jsdoc';
+import { PORT } from '../../../config/backend.config.mjs';
+
+// Swagger definition
+const swaggerDefinition = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Glizzy Gobbler 4000 API',
+    version: '0.1.0',
+    description: 'A multi-tenant MERN application API with role-based access control',
+    contact: {
+      name: 'API Support',
+      email: 'support@example.com'
+    },
+    license: {
+      name: 'MIT',
+      url: 'https://opensource.org/licenses/MIT'
+    }
+  },
+  servers: [
+    {
+      url: `http://localhost:${PORT}/api`,
+      description: 'Development server'
+    }
+  ],
+  components: {
+    securitySchemes: {
+      cookieAuth: {
+        type: 'apiKey',
+        in: 'cookie',
+        name: 'token'
+      }
+    },
+    responses: {
+      UnauthorizedError: {
+        description: 'Access token is missing or invalid',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                message: {
+                  type: 'string',
+                  example: 'Unauthorized - Not authenticated'
+                }
+              }
+            }
+          }
+        }
+      },
+      ForbiddenError: {
+        description: 'User does not have permission for this action',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                message: {
+                  type: 'string',
+                  example: 'Forbidden - Insufficient permissions'
+                }
+              }
+            }
+          }
+        }
+      },
+      ServerError: {
+        description: 'Internal server error',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                message: {
+                  type: 'string',
+                  example: 'Server error'
+                },
+                stack: {
+                  type: 'string',
+                  example: 'Error stack trace (only in development)'
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    schemas: {
+      User: {
+        type: 'object',
+        required: ['username', 'email', 'password'],
+        properties: {
+          _id: {
+            type: 'string',
+            description: 'User ID (auto-generated)',
+            example: '60d0fe4f5311236168a109ca'
+          },
+          username: {
+            type: 'string',
+            description: 'User username',
+            example: 'johndoe'
+          },
+          email: {
+            type: 'string',
+            format: 'email',
+            description: 'User email address',
+            example: 'john.doe@example.com'
+          },
+          password: {
+            type: 'string',
+            format: 'password',
+            description: 'User password (hashed)',
+            example: 'password123'
+          },
+          isSystemAdmin: {
+            type: 'boolean',
+            description: 'Whether the user has system admin privileges',
+            example: false
+          },
+          tenantRoles: {
+            type: 'array',
+            description: 'Roles assigned to the user per tenant',
+            items: {
+              type: 'object',
+              properties: {
+                tenantId: {
+                  type: 'string',
+                  description: 'ID of the tenant',
+                  example: '60d0fe4f5311236168a109cb'
+                },
+                role: {
+                  type: 'string',
+                  enum: ['admin', 'author', 'user'],
+                  description: 'Role within the tenant',
+                  example: 'admin'
+                }
+              }
+            }
+          },
+          createdAt: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Date user was created',
+            example: '2021-06-21T12:00:00Z'
+          },
+          updatedAt: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Date user was last updated',
+            example: '2021-06-21T12:00:00Z'
+          },
+          lastLogin: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Date user last logged in',
+            example: '2021-06-21T12:00:00Z'
+          }
+        }
+      },
+      UserResponse: {
+        type: 'object',
+        properties: {
+          _id: {
+            type: 'string',
+            description: 'User ID',
+            example: '60d0fe4f5311236168a109ca'
+          },
+          username: {
+            type: 'string',
+            description: 'User username',
+            example: 'johndoe'
+          },
+          email: {
+            type: 'string',
+            format: 'email',
+            description: 'User email address',
+            example: 'john.doe@example.com'
+          },
+          isSystemAdmin: {
+            type: 'boolean',
+            description: 'Whether the user has system admin privileges',
+            example: false
+          }
+        }
+      },
+      LoginRequest: {
+        type: 'object',
+        required: ['email', 'password'],
+        properties: {
+          email: {
+            type: 'string',
+            format: 'email',
+            description: 'User email address',
+            example: 'john.doe@example.com'
+          },
+          password: {
+            type: 'string',
+            format: 'password',
+            description: 'User password',
+            example: 'password123'
+          }
+        }
+      },
+      RegisterRequest: {
+        type: 'object',
+        required: ['username', 'email', 'password'],
+        properties: {
+          username: {
+            type: 'string',
+            description: 'User username',
+            example: 'johndoe'
+          },
+          email: {
+            type: 'string',
+            format: 'email',
+            description: 'User email address',
+            example: 'john.doe@example.com'
+          },
+          password: {
+            type: 'string',
+            format: 'password',
+            description: 'User password',
+            example: 'password123'
+          }
+        }
+      },
+      Tenant: {
+        type: 'object',
+        required: ['name'],
+        properties: {
+          _id: {
+            type: 'string',
+            description: 'Tenant ID (auto-generated)',
+            example: '60d0fe4f5311236168a109cb'
+          },
+          name: {
+            type: 'string',
+            description: 'Tenant name',
+            example: 'Acme Corporation'
+          },
+          slug: {
+            type: 'string',
+            description: 'URL-friendly tenant identifier',
+            example: 'acme-corporation'
+          },
+          description: {
+            type: 'string',
+            description: 'Tenant description',
+            example: 'A multinational corporation providing various products and services'
+          },
+          status: {
+            type: 'string',
+            enum: ['active', 'inactive', 'suspended'],
+            description: 'Tenant status',
+            example: 'active'
+          },
+          createdAt: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Date tenant was created',
+            example: '2021-06-21T12:00:00Z'
+          },
+          updatedAt: {
+            type: 'string',
+            format: 'date-time',
+            description: 'Date tenant was last updated',
+            example: '2021-06-21T12:00:00Z'
+          }
+        }
+      },
+      Error: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            description: 'Error message',
+            example: 'An error occurred'
+          }
+        }
+      }
+    }
+  },
+  tags: [
+    {
+      name: 'Auth',
+      description: 'Authentication operations'
+    },
+    {
+      name: 'Users',
+      description: 'User management operations'
+    },
+    {
+      name: 'Tenants',
+      description: 'Tenant management operations'
+    }
+  ]
+};
+
+// Options for the swagger docs
+const options = {
+  // Import swaggerDefinitions
+  swaggerDefinition,
+  // Path to the API docs
+  apis: [
+    './src/routes/*.mjs',
+    './src/controllers/*.mjs',
+    './src/models/*.mjs'
+  ],
+};
+
+// Initialize swagger-jsdoc
+const swaggerSpec = swaggerJSDoc(options);
+
+export default swaggerSpec;


### PR DESCRIPTION
## Description

This PR implements Swagger UI for API documentation as described in Issue #9. It adds comprehensive API documentation for all existing endpoints, with a focus on the authentication routes.

## Changes

- Added swagger-jsdoc and swagger-ui-express integration
- Created a Swagger configuration file with OpenAPI specification
- Added JSDoc comments to document existing routes and controllers
- Added Swagger documentation for all authentication endpoints
- Created a documentation README with instructions for using Swagger UI
- Ensured security schemes (JWT via cookies) are properly documented

## Testing

To test this implementation:

1. Start the backend server with `npm run dev:backend`
2. Access the Swagger UI at: http://localhost:5000/api-docs
3. Verify that all authentication endpoints are properly documented
4. Test the API endpoints directly from the Swagger UI interface

## Screenshots

(Screenshots would be added here when available)

## Related Issues

Closes #9

